### PR TITLE
require 'ostruct' in lib/reform.rb

### DIFF
--- a/lib/reform.rb
+++ b/lib/reform.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'reform/version'
 require 'reform/form'
 require 'reform/form/dsl'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
 require 'test/unit'
 require 'minitest/spec'
-require 'ostruct'
 require 'reform'


### PR DESCRIPTION
reform/form uses OpenStruct but it was never required explicitly.
