### PR TITLE
allow rails users to have non-active_record forms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+h3. 0.1.2
+
+* Altered `reform/rails` to conditionally load `ActiveRecord` code and created `reform/active_record`
+
 h3. 0.1.1
 
 * Added `reform/rails` that requires everything you need (even in other frameworks :).

--- a/lib/reform/active_record.rb
+++ b/lib/reform/active_record.rb
@@ -1,0 +1,2 @@
+require 'reform/form/active_model'
+require 'reform/form/active_record'

--- a/lib/reform/rails.rb
+++ b/lib/reform/rails.rb
@@ -1,2 +1,4 @@
 require 'reform/form/active_model'
-require 'reform/form/active_record'
+if defined?(ActiveRecord)
+  require 'reform/form/active_record'
+end

--- a/lib/reform/version.rb
+++ b/lib/reform/version.rb
@@ -1,3 +1,3 @@
 module Reform
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
This change allows users to `require 'reform/rails'` even if they aren't using ActiveRecord.
