### PR TITLE
Delegate #to_model method to model

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -11,7 +11,7 @@ module Reform::Form::ActiveModel
       composition_model = options[:on] || main_model
 
       delegate composition_model, :to => :model  # #song => model.song
-      delegate :persisted?, :to_key, :to_param, :to => composition_model  # #to_key => song.to_key
+      delegate :persisted?, :to_key, :to_param, :to_model, :to => composition_model  # #to_key => song.to_key
 
       alias_method main_model, composition_model # #hit => model.song.
     end

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -54,6 +54,10 @@ class ActiveModelTest < MiniTest::Spec
     HitForm.new(:song => OpenStruct.new.instance_eval { def to_param; "yo!"; end; self }, :artist => OpenStruct.new).to_param.must_equal "yo!"
   end
 
+  it "provides #to_model" do
+    HitForm.new(:song => OpenStruct.new.instance_eval { def to_model; "yo!"; end; self }, :artist => OpenStruct.new).to_model.must_equal "yo!"
+  end
+
   it "works with any order of ::model and ::property" do
     class AnotherForm < Reform::Form
       include DSL


### PR DESCRIPTION
`ActiveModel::Conversion#to_model` is required to build correct URLs with form object.

Before patch:

``` ruby
form_object = ApplicantForm.new(applicant: applicant, profile: applicant.profile)
url_for(form_object) #=> /applicants/1?id=%23%3CReform%3A%3AFields+email%3D%22soulim%40gmail.com%22%2C+first_name%3Dnil%2C+last_name%3Dnil%3E
```

After patch:

``` ruby
form_object = ApplicantForm.new(applicant: applicant, profile: applicant.profile)
url_for(form_object) #=> /applicants/1
```
