### PR TITLE
Support column type interrogation

### DIFF
--- a/lib/reform/form/active_record.rb
+++ b/lib/reform/form/active_record.rb
@@ -1,4 +1,13 @@
 class Reform::Form
+  # delegate column for attribute to the model
+  # this supports simple_form's attribute type
+  # interrogation
+  def column_for_attribute(name)
+    if @model.respond_to?(:column_for_attribute)
+      @model.column_for_attribute(name)
+    end
+  end
+
   module ActiveRecord
     def self.included(base)
       base.class_eval do

--- a/test/reform_test.rb
+++ b/test/reform_test.rb
@@ -236,4 +236,28 @@ class ReformTest < ReformSpec
   describe "#model" do
     it { form.send(:model).must_equal comp }
   end
+
+  describe "#column_for_attribute" do
+    let (:model) { Artist.new }
+    let (:klass) do
+      require 'reform/active_record'
+      Class.new(Reform::Form) do
+        include Reform::Form::ActiveRecord
+        model :artist
+
+        property :name
+      end
+    end
+    let (:form) { klass.new(model) }
+
+    it 'should delegate to the model' do
+      Calls = []
+      def model.column_for_attribute(name)
+        Calls << :column_for_attribute
+      end
+
+      form.column_for_attribute(:name)
+      Calls.must_include :column_for_attribute
+    end
+  end
 end


### PR DESCRIPTION
Delegate to the model for `column_for_attribute`

Implement `column_for_attribute` on reform enabled forms. simple-form and
formtastic call `column_for_attribute` on the form object in order to
determine which html input tag to generate for a particular field.

See: https://github.com/plataformatec/simple_form/blob/master/lib/simple_form/form_builder.rb#L525
