### PR TITLE
Add uniqueness_validation exception to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,13 @@ Reform provides the following `ActiveRecord` specific features. They're mixed in
  * Uniqueness validations. Use `validates_uniqueness_of` in your form.
  * Calling `Form#save` will explicitely call `save` on your model (added in 0.2.1) which will usually trigger a database insertion or update.
 
+As mentioned in the [Rails Integration](https://github.com/apotonick/reform#rails-integration) section; some Rails 4 setup's do not properly load Form::ActiveRecord; in these cases you can choose to include
+
+```ruby
+include Reform::Form::ActiveRecord
+```
+
+in your form class definition manually to enable the mentioned `validates_uniqueness_of` functionality in your forms.
 
 ## ActiveModel Compliance
 


### PR DESCRIPTION
In some cases the helper methods for uniqueness validation are not
properly mixed in (as mentioned in the Rails integration section); added
a manual workaround for this case.
