### PR TITLE
Test behaviour for nil or empty objects

### DIFF
--- a/test/nested_form_test.rb
+++ b/test/nested_form_test.rb
@@ -47,8 +47,35 @@ class NestedFormTest < MiniTest::Spec
     form.songs.must_be_kind_of Reform::Form::Forms
   end
   describe "#initialize" do
-    it "allows empty properties" do
-      AlbumForm.new(OpenStruct.new)
+    describe "with empty object" do
+      let(:albumn_with_empty_openstruct) { AlbumForm.new(OpenStruct.new) }
+      it "allows initialization with empty properties" do
+        albumn_with_empty_openstruct
+      end
+      it "must support #validate when initialized with empty properties" do
+        albumn_with_empty_openstruct.validate({})
+        albumn_with_empty_openstruct.errors.messages.must_equal(:title=>["can't be blank"], :"hit.title"=>["can't be blank"], :"songs.title"=>["can't be blank"])
+      end
+      it "must support #validate with attributes when initialized with empty properties" do
+        albumn_with_empty_openstruct.validate("hit"=>{"title"=>"Downtown"}, "title" => "Blackhawks Over Los Angeles", "songs"=>[{"title"=>"Calling"}])
+        albumn_with_empty_openstruct.title.must_eql "Blackhawks Over Los Angeles"
+        albumn_with_empty_openstruct.errors.messages.must_equal([])
+      end
+    end
+    describe "with no argument (effectively nil)" do
+      let(:albumn_with_no_model) { AlbumForm.new }
+      it "allows initialization with nil object" do
+        albumn_with_no_model
+      end
+      it "must support #validate when initialized with a nil object" do
+        albumn_with_no_model.validate({})
+        albumn_with_no_model.errors.messages.must_equal(:title=>["can't be blank"], :"hit.title"=>["can't be blank"], :"songs.title"=>["can't be blank"])
+      end
+      it "must support #validate with attributes when initialized with empty properties" do
+        albumn_with_no_model.validate({"hit"=>{"title"=>"Downtown"}, "title" => "Blackhawks Over Los Angeles", "songs"=>[{"title"=>"Calling"}]})
+        albumn_with_empty_openstruct.title.must_eql "Blackhawks Over Los Angeles"
+        albumn_with_empty_openstruct.errors.messages.must_equal([])
+      end
     end
   end
 


### PR DESCRIPTION
If you are going to support empty objects, then I think you need to address how the validators and attributes will work when the object is nil.

I have also added a test for initialization without any object behind it.  I would expect this to be have similarly.

This follows the discussion on https://github.com/apotonick/reform/issues/67#issuecomment-37803923

Thanks.
