### PR TITLE
Adding Github as homepage

### DIFF
--- a/reform.gemspec
+++ b/reform.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["apotonick@gmail.com", "heinleng@gmail.com"]
   spec.description   = %q{Freeing your AR models from form logic.}
   spec.summary       = %q{Decouples your models from form by giving you form objects with validation, presentation, workflows and security.}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/apotonick/reform"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
When I'm looking at a gemspec, I can see which gems are used.
To then attempt to find where those gems are defined, I invariably go
to https://rubygems.org/gem/<name_of_gem>. Once there I would like to
see a link to the homepage of that gem. In most cases the Github
repository is adequate.
