### PR TITLE
Automatically include ActiveRecord module in reform/rails

### DIFF
--- a/lib/reform/rails.rb
+++ b/lib/reform/rails.rb
@@ -6,4 +6,5 @@ end
 Reform::Form.class_eval do # DISCUSS: i'd prefer having a separate Rails module to be mixed into the Form but this is way more convenient for 99% users.
   include Reform::Form::ActiveModel
   include Reform::Form::ActiveModel::FormBuilderMethods
+  include Reform::Form::ActiveRecord if defined?(ActiveRecord)
 end


### PR DESCRIPTION
This is how I would have assumed that the module is included automatically, but it looks like that never happens. This should fix #72.

Is the `if defined?` okay like that or would you want to arrange it differently?
