### PR TITLE
Support column_for_attribute in Forms that use Composition

### DIFF
--- a/lib/reform/form/active_record.rb
+++ b/lib/reform/form/active_record.rb
@@ -44,6 +44,6 @@ module Reform::Form::ActiveRecord
   # Delegate column for attribute to the model to support simple_form's
   # attribute type interrogation.
   def column_for_attribute(name)
-    model.column_for_attribute(name)
+    model_for_property(name).column_for_attribute(name)
   end
 end


### PR DESCRIPTION
Add support for `column_for_attribute` (used in `simple_form` for checking the attribute type) in Forms that use Composition, with tests.
