### PR TITLE
updated README about contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ In future versions and with the upcoming [Trailblazer framework](https://github.
 
 ### Using Contracts
 
-Applying a contract is simple, all you need is a populated object (e.g. an album after `#update_attributes`).
+Applying a contract is simple, all you need is a populated object (e.g. an album after `#assign_attributes`).
 
 ```ruby
 album.assign_attributes(..)


### PR DESCRIPTION
It seems to me that `README` contains a small typo. Instead of asking a user to `update_attributes` before calling `validate` we should rather `assign` them (as `update_attributes` would silently change the basic model object without `contract`'s validations).
More then that, code sample below that part of `README` points to `assign_attributes` method aswell.

> Applying a contract is simple, all you need is a populated object (e.g. an album after #**update_attributes**).
> 
>    album.**assign_attributes**(..)
