### PR TITLE
Undefined method 'has_attribute?' from simple form

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -53,7 +53,7 @@ module Reform::Form::ActiveModel
       extend ClassMethods
       register_feature ActiveModel
 
-      delegates :model, *[:persisted?, :to_key, :to_param, :id] # Uber::Delegates
+      delegates :model, *[:persisted?, :to_key, :to_param, :id, :has_attribute?] # Uber::Delegates
 
       def to_model # this is called somewhere in FormBuilder and ActionController.
         self

--- a/lib/reform/form/composition.rb
+++ b/lib/reform/form/composition.rb
@@ -27,7 +27,7 @@ module Reform::Form::Composition
       composition_model = options[:on] || main_model
 
       # FIXME: this should just delegate to :model as in FB, and the comp would take care of it internally.
-      [:persisted?, :to_key, :to_param].each do |method|
+      [:persisted?, :to_key, :to_param, :has_attribute?].each do |method|
         define_method method do
           model[composition_model].send(method)
         end

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -13,6 +13,7 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
   it { form.persisted?.must_equal true }
   it { form.to_key.must_equal [artist.id] }
   it { form.to_param.must_equal "#{artist.id}" }
+  it { form.has_attribute?(:name).must_equal true }
   it { form.to_model.must_equal form }
   it { form.id.must_equal artist.id }
 

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -144,6 +144,10 @@ class ActiveModelWithCompositionTest < MiniTest::Spec
     HitForm.new(:song => OpenStruct.new.instance_eval { def to_param; "yo!"; end; self }, :artist => OpenStruct.new).to_param.must_equal "yo!"
   end
 
+  it "provides #has_attribute?" do
+    HitForm.new(:song => OpenStruct.new.instance_eval { def has_attribute?; "yo!"; end; self }, :artist => OpenStruct.new).has_attribute?.must_equal "yo!"
+  end
+
   it "provides #to_model" do
     form = HitForm.new(:song => OpenStruct.new, :artist => OpenStruct.new)
     form.to_model.must_equal form


### PR DESCRIPTION
SimpleForm expects a model to respond to has_attribute? while building a form in the view. I just updated from Reform v1.0.4 to v1.1.1 and SimpleForm started throwing and undefined method error.

This PR adds the behavior back in to appease SimpleForm.