### PR TITLE
Form syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,12 @@ class SongForm < Reform::Form
 end
 ```
 
-Or, if you prefer, specify validations separately:
+Or, if you prefer, specify validations separately. You can also add multiple properties if they
+share the same options (`properties` works too).
 
 ```ruby
 class SongForm < Reform::Form
-  property :title
-  property :length
-
-  validates :title,  presence: true
+  property :title, :length, validates: {presence: true}
   validates :length, numericality: true
 end
 ```

--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -10,13 +10,14 @@ module Reform::Form::ActiveModel
     end
 
     module ClassMethods
-      def property(name, options={})
+      private
+
+      def add_property(name, options={})
         super.tap do |definition|
           add_nested_attribute_compat(name) if definition[:form] # TODO: fix that in Rails FB#1832 work.
         end
       end
 
-    private
       # The Rails FormBuilder "detects" nested attributes (which is what we want) by checking existance of a setter method.
       def add_nested_attribute_compat(name)
         define_method("#{name}_attributes=") {} # this is why i hate respond_to? in Rails.

--- a/lib/reform/form/scalar.rb
+++ b/lib/reform/form/scalar.rb
@@ -41,7 +41,9 @@ module Reform::Form::Scalar
 
   # TODO: change the way i hook into ::property.
   module Property
-    def property(name, options={}, &block)
+    private
+
+    def add_property(name, options={}, &block)
       if options[:scalar]
         options.merge!(:features => [Reform::Form::Scalar], populate_if_empty: String)
       end

--- a/reform.gemspec
+++ b/reform.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "virtus"
   spec.add_development_dependency "rails"
+  spec.add_development_dependency "mocha"
 
   spec.add_development_dependency "actionpack"
 end

--- a/test/form_syntax_test.rb
+++ b/test/form_syntax_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'mocha/mini_test'
 
 describe Reform::Form do
   let(:form_class) do
@@ -27,6 +28,33 @@ describe Reform::Form do
     describe "with title" do
       it "passes validation" do
         form.validate(title: "yeah").must_equal true
+      end
+    end
+  end
+
+  describe "adding multiple properties" do
+    it "adds multiple fields" do
+      form_class.class_eval do
+        property :first_name, :last_name
+      end
+      form.send(:fields).methods(false).must_include(:first_name)
+      form.send(:fields).methods(false).must_include(:last_name)
+    end
+
+    it "accepts multiple fields in an array (legacy syntax for .properties)" do
+      form_class.class_eval do
+        property [:first_name, :last_name]
+      end
+      form.send(:fields).methods(false).must_include(:first_name)
+      form.send(:fields).methods(false).must_include(:last_name)
+    end
+  end
+
+  describe '.properties' do
+    it "calls .property" do
+      form_class.expects(:property).with(:foo)
+      form_class.class_eval do
+        properties :foo
       end
     end
   end


### PR DESCRIPTION
Two commits here:
- inline validation definition (ie `property :foo, validates: {presence: true}`)
- bulk-add properties (ie `property :foo, :bar, :baz`)
