### PR TITLE
Added handling for errors specified in a nested form with a :base key.

### DIFF
--- a/lib/reform/contract/errors.rb
+++ b/lib/reform/contract/errors.rb
@@ -16,7 +16,9 @@ class Reform::Contract::Errors < ActiveModel::Errors
 
     # TODO: merge into AM.
     errors.messages.each do |field, msgs|
-      field = (prefix+[field]).join(".").to_sym # TODO: why is that a symbol in Rails?
+      unless field.to_sym == :base
+        field = (prefix+[field]).join(".").to_sym # TODO: why is that a symbol in Rails?
+      end
 
       msgs = [msgs] if Reform.rails3_0? # DISCUSS: fix in #each?
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -15,11 +15,18 @@ class ErrorsTest < MiniTest::Spec
     end
 
     property :band do # yepp, people do crazy stuff like that.
+      property :name
       property :label do
         property :name
         validates :name, :presence => true
       end
       # TODO: make band a required object.
+
+      validate :validate_musical_taste
+
+      def validate_musical_taste
+        errors.add(:base, "You are a bad person") if name == 'Nickelback'
+      end
     end
 
     validates :title, :presence => true
@@ -105,6 +112,12 @@ class ErrorsTest < MiniTest::Spec
     it { form.errors.messages.must_equal({:"songs.title"=>["can't be blank"], :"band.label.name"=>["can't be blank"]}) }
   end
 
+  describe "#validate with nested form using :base invalid" do
+    before { @result = form.validate("songs"=>[{"title" => "Someday"}], "band" => {"name" => "Nickelback", "label" => {"name" => "Roadrunner Records"}}) }
+
+    it { @result.must_equal false }
+    it { form.errors.messages.must_equal({:base=>["You are a bad person"]}) }
+  end
 
   describe "correct #validate" do
     before { @result = form.validate(

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class SyncTest < BaseTest
+
+  Band = Struct.new(:name, :label)
+
   describe "populated" do
     let (:params) {
       {
@@ -15,7 +18,7 @@ class SyncTest < BaseTest
     let (:hit) { Song.new }
     let (:song1) { Song.new }
     let (:song2) { Song.new }
-    let (:band) { Band.new(label) }
+    let (:band) { Band.new("The Police", label) }
     let (:label) { Label.new }
 
     subject { ErrorsTest::AlbumForm.new(album) }


### PR DESCRIPTION
Base errors should not have the child name prepended. :base now remains :base, not :"child.base" when added from a nested form.
