### PR TITLE
Fix isolated engine namespace

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -92,7 +92,17 @@ module Reform::Form::ActiveModel
   private
     def active_model_name_for(string)
       return ::ActiveModel::Name.new(OpenStruct.new(:name => string)) if Reform.rails3_0?
-      ::ActiveModel::Name.new(self, nil, string)
+      ::ActiveModel::Name.new(self, determine_namespace(string) , string)
+    end
+
+    def determine_namespace(string)
+      begin
+        string.constantize.parents.detect do |n|
+          n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
+        end
+      rescue NameError
+        nil
+      end
     end
   end
 end

--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -96,12 +96,9 @@ module Reform::Form::ActiveModel
     end
 
     def determine_namespace(string)
-      begin
-        string.constantize.parents.detect do |n|
-          n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
-        end
-      rescue NameError
-        nil
+      return nil unless Module.const_defined?(string)
+      string.constantize.parents.detect do |n|
+        n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
       end
     end
   end

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -19,6 +19,7 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
   describe "::model_name" do
     it { form.class.model_name.must_be_kind_of ActiveModel::Name }
     it { form.class.model_name.to_s.must_equal "NewActiveModelTest::Song" }
+    it { form.class.model_name.route_key.must_equal "new_active_model_test_songs" }
 
     let (:class_with_model) {
       Class.new(Reform::Form) do
@@ -30,7 +31,31 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
 
     it { class_with_model.model_name.must_be_kind_of ActiveModel::Name }
     it { class_with_model.model_name.to_s.must_equal "Album" }
+    it { class_with_model.model_name.route_key.must_equal "albums" }
 
+    let (:class_with_isolated_model) {
+      Class.new(Reform::Form) do
+        include Reform::Form::ActiveModel
+
+        model IsolatedRailsEngine::Lyric
+      end
+    }
+
+    it { class_with_isolated_model.model_name.must_be_kind_of ActiveModel::Name }
+    it { class_with_isolated_model.model_name.to_s.must_equal "IsolatedRailsEngine::Lyric" }
+    it { class_with_isolated_model.model_name.route_key.must_equal "lyrics" }
+
+    let (:class_with_namespace_model) {
+      Class.new(Reform::Form) do
+        include Reform::Form::ActiveModel
+
+        model NormalRailsEngine::Lyric
+      end
+    }
+
+    it { class_with_namespace_model.model_name.must_be_kind_of ActiveModel::Name }
+    it { class_with_namespace_model.model_name.to_s.must_equal "NormalRailsEngine::Lyric" }
+    it { class_with_namespace_model.model_name.route_key.must_equal "normal_rails_engine_lyrics" }
 
     let (:subclass_of_class_with_model) {
       Class.new(class_with_model)
@@ -38,6 +63,7 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
 
     it { subclass_of_class_with_model.model_name.must_be_kind_of ActiveModel::Name }
     it { subclass_of_class_with_model.model_name.to_s.must_equal 'Album' }
+    it { subclass_of_class_with_model.model_name.route_key.must_equal 'albums' }
 
 
     describe "class named Song::Form" do

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -19,7 +19,6 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
   describe "::model_name" do
     it { form.class.model_name.must_be_kind_of ActiveModel::Name }
     it { form.class.model_name.to_s.must_equal "NewActiveModelTest::Song" }
-    it { form.class.model_name.route_key.must_equal "new_active_model_test_songs" }
 
     let (:class_with_model) {
       Class.new(Reform::Form) do
@@ -31,7 +30,6 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
 
     it { class_with_model.model_name.must_be_kind_of ActiveModel::Name }
     it { class_with_model.model_name.to_s.must_equal "Album" }
-    it { class_with_model.model_name.route_key.must_equal "albums" }
 
     let (:class_with_isolated_model) {
       Class.new(Reform::Form) do
@@ -43,7 +41,6 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
 
     it { class_with_isolated_model.model_name.must_be_kind_of ActiveModel::Name }
     it { class_with_isolated_model.model_name.to_s.must_equal "IsolatedRailsEngine::Lyric" }
-    it { class_with_isolated_model.model_name.route_key.must_equal "lyrics" }
 
     let (:class_with_namespace_model) {
       Class.new(Reform::Form) do
@@ -55,7 +52,6 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
 
     it { class_with_namespace_model.model_name.must_be_kind_of ActiveModel::Name }
     it { class_with_namespace_model.model_name.to_s.must_equal "NormalRailsEngine::Lyric" }
-    it { class_with_namespace_model.model_name.route_key.must_equal "normal_rails_engine_lyrics" }
 
     let (:subclass_of_class_with_model) {
       Class.new(class_with_model)
@@ -63,8 +59,14 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
 
     it { subclass_of_class_with_model.model_name.must_be_kind_of ActiveModel::Name }
     it { subclass_of_class_with_model.model_name.to_s.must_equal 'Album' }
-    it { subclass_of_class_with_model.model_name.route_key.must_equal 'albums' }
 
+    unless Reform.rails3_0?
+      it { form.class.model_name.route_key.must_equal "new_active_model_test_songs" }
+      it { class_with_model.model_name.route_key.must_equal "albums" }
+      it { class_with_isolated_model.model_name.route_key.must_equal "lyrics" }
+      it { class_with_namespace_model.model_name.route_key.must_equal "normal_rails_engine_lyrics" }
+      it { subclass_of_class_with_model.model_name.route_key.must_equal 'albums' }
+    end
 
     describe "class named Song::Form" do
       it do

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -35,7 +35,7 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
       Class.new(Reform::Form) do
         include Reform::Form::ActiveModel
 
-        model IsolatedRailsEngine::Lyric
+        model "isolated_rails_engine/lyric", namespace: "isolated_rails_engine"
       end
     }
 
@@ -46,7 +46,7 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
       Class.new(Reform::Form) do
         include Reform::Form::ActiveModel
 
-        model NormalRailsEngine::Lyric
+        model "normal_rails_engine/lyric"
       end
     }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,20 @@ class Album < ActiveRecord::Base
   has_many :songs
 end
 
+module IsolatedRailsEngine
+  def self.use_relative_model_naming?
+    true
+  end
+
+  class Lyric < ActiveRecord::Base
+  end
+end
+
+module NormalRailsEngine
+  class Lyric < ActiveRecord::Base
+  end
+end
+
 ActiveRecord::Base.establish_connection(
   :adapter => "sqlite3",
   :database => "#{Dir.pwd}/database.sqlite3"


### PR DESCRIPTION
This is a fix to determine the correct route_key for Model defined in namespace-isolated rails engine.

I have a namespace-isolated rails engine(let's say, named `project_core` ), which mainly store the shared models and service objects between different rails apps (let's say, named `project_frontend` and `proejct_backend` )

``` ruby
module ProjectCore
  class Lyric < ActiveRecord::Base
  end
end
```

And then I define a Form object in `project_backend`.
``` ruby
class CreateLyricForm < Reform::Form
  property :data

  model ProjectCore::Lyric  
end
```

And related `LyricController` in `project_backend` app
``` ruby
class LyricController < ApplicationController
  def new
     @form = CreateLyricForm.new( ProjectCore::Lyric.new )
  end
end
```

And a form_for statement for this create form in `project_backend` related view
``` ruby
<%= form_for @form do |f| %>
  ....
<% end %>
```

Oh, BTW, and define resouces route for this LyricController as well
``` ruby
Rails.application.routes.draw do
  resources :lyrices
end
```

**This is where the whole story begins**

When the system render the view, it would lookup the registered routes, and return a error:
```
ActionView::Template::Error:
       undefined method `project_core_lyrics_path' for
```
the route_key return by `CreateLyricForm.model_name.route_key` is "proejct_core_lyrics", but it is incorrect in this case. 

After this fix, **intended to correct route_key for namespaced model in Isolated Namepace**, the route_key is corrected to "lyrices".

@apotonick, please let me know what you think about this fix! :-D 



