### PR TITLE
Add support for isolated namespaces in `#model_name`

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -92,7 +92,17 @@ module Reform::Form::ActiveModel
   private
     def active_model_name_for(string)
       return ::ActiveModel::Name.new(OpenStruct.new(:name => string)) if Reform.rails3_0?
-      ::ActiveModel::Name.new(self, nil, string)
+
+      begin
+        klass = string.constantize
+        namespace = klass.parents.detect do |n|
+          n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
+        end
+      rescue NameError
+        namespace = nil
+      end
+
+      ::ActiveModel::Name.new(self, namespace, string)
     end
   end
 end


### PR DESCRIPTION
When the class is in an isolated namespace, the namespace has to be
defined to generate the correct route key in `ActiveModel::Name`.