### PR TITLE
Include a note about ModelReflections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,17 @@ class SongForm < Reform::Form
 end
 ```
 
+### Simple Form
+
+If you want full support for `simple_form` do as follows.
+
+```ruby
+class SongForm < Reform::Form
+  include ModelReflections
+```
+
+Including this module will add `#column_for_attribute` and other methods need by form builders to automatically guess the type of a property.
+
 ## Validations For File Uploads
 
 In case you're processing uploaded files with your form using CarrierWave, Paperclip, Dragonfly or Paperdragon we recommend using the awesome [file_validators](https://github.com/musaffa/file_validators) gem for file type and size validations.


### PR DESCRIPTION
While diving into reform I noticed that there is no info about input type guess for simple_form, but afterwards I found a note about that [in changelog][1].
This PR adds the note to README to avoid confusion.







[1]: https://github.com/apotonick/reform/blob/master/CHANGES.md#breakage