### PR TITLE
Add support for DateTime select in `MultiParameterAttributes`

### DIFF
--- a/lib/reform/form/multi_parameter_attributes.rb
+++ b/lib/reform/form/multi_parameter_attributes.rb
@@ -4,41 +4,47 @@ Reform::Form.class_eval do
       base.send(:register_feature, self)
     end
 
-    class DateParamsFilter
+    class DateTimeParamsFilter
       def call(params)
-        date_attributes = {}
-
-        params.each do |attribute, value|
+        params.each_with_object({}) do |(attribute, value), hsh|
           if value.is_a?(Hash)
-            call(value) # TODO: #validate should only handle local form params.
+            hsh[attribute] = call(value) # TODO: #validate should only handle local form params.
           elsif matches = attribute.match(/^(\w+)\(.i\)$/)
             date_attribute = matches[1]
-            date_attributes[date_attribute] = params_to_date(
-              params.delete("#{date_attribute}(1i)"),
-              params.delete("#{date_attribute}(2i)"),
-              params.delete("#{date_attribute}(3i)")
-            )
+
+            unless hsh.key?(date_attribute)
+              hsh[date_attribute] = params_to_date(
+                params["#{date_attribute}(1i)"],
+                params["#{date_attribute}(2i)"],
+                params["#{date_attribute}(3i)"],
+                params["#{date_attribute}(4i)"],
+                params["#{date_attribute}(5i)"]
+              )
+            end
+          else
+            hsh[attribute] = value
           end
         end
-        params.merge!(date_attributes)
       end
 
     private
-      def params_to_date(year, month, day)
-        return nil if blank_date_parameter?(year, month, day)
+      def params_to_date(year, month, day, hour, minute)
+        return nil if [year, month, day].any?(&:blank?)
 
-        Date.new(year.to_i, month.to_i, day.to_i) # TODO: test fails.
-      end
-
-      def blank_date_parameter?(year, month, day)
-        year.blank? || month.blank? || day.blank?
+        if hour.blank? && minute.blank?
+          Date.new(year.to_i, month.to_i, day.to_i) # TODO: test fails.
+        else
+          args = [year, month, day, hour, minute].map(&:to_i)
+          Time.zone ? Time.zone.local(*args) :
+            Time.new(*args)
+        end
       end
     end
 
     def validate(params)
       # TODO: make it cleaner to hook into essential reform steps.
       # TODO: test with nested.
-      DateParamsFilter.new.call(params) if params.is_a?(Hash) # this currently works for hash, only.
+      params = DateTimeParamsFilter.new.call(params) if params.is_a?(Hash) # this currently works for hash, only.
 
       super
     end

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -64,23 +64,37 @@ class FormBuilderCompatTest < BaseTest
     form.must_respond_to("label_attributes=")
   end
 
-  describe "deconstructed date parameters" do
+  describe "deconstructed datetime parameters" do
     let(:form_attributes) do
       {
         "artist_attributes" => {"name" => "Blink 182"},
         "songs_attributes" => {"0" => {"title" => "Damnit", "release_date(1i)" => release_year,
-          "release_date(2i)" => release_month, "release_date(3i)" => release_day}}
+          "release_date(2i)" => release_month, "release_date(3i)" => release_day,
+          "release_date(4i)" => release_hour, "release_date(5i)" => release_minute}}
       }
     end
     let(:release_year) { "1997" }
     let(:release_month) { "9" }
     let(:release_day) { "27" }
+    let(:release_hour) { nil }
+    let(:release_minute) { nil }
 
-    describe "with valid parameters" do
+    describe "with valid date parameters" do
       it "creates a date" do
         form.validate(form_attributes)
 
         form.songs.first.release_date.must_equal Date.new(1997, 9, 27)
+      end
+    end
+
+    describe "with valid datetime parameters" do
+      let(:release_hour) { "10" }
+      let(:release_minute) { "11" }
+
+      it "creates a datetime" do
+        form.validate(form_attributes)
+
+        form.songs.first.release_date.must_equal Time.new(1997, 9, 27, 10, 11)
       end
     end
 


### PR DESCRIPTION
Rails has an helper for a datetime_select (http://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html#method-i-datetime_select) which cannot be used with Reform because the `DateParamsFilter` will try to convert it into a date without using the params for hours (4i) and minutes (5i).

I tried to handle those params too and to generate a `Time` object using the correct timezone.

I also added a `#dup` on the `params` hash. I don't know what you think about that, but at first I didn't understand why the `params` hash in my controller was not the same as the parameters I was sending in my form so I think it's better to work with a copy of this hash.