### PR TITLE
Correct Failing Tests

### DIFF
--- a/test/model_reflections_test.rb
+++ b/test/model_reflections_test.rb
@@ -85,7 +85,7 @@ class ModelReflectionTest < MiniTest::Spec
     # delegate to model class.
     it do
       reflection = form.class.reflect_on_association(:artist)
-      reflection.must_be_instance_of ActiveRecord::Reflection::AssociationReflection
+      reflection.must_be_kind_of ActiveRecord::Reflection::AssociationReflection
     end
   end
 

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -261,7 +261,7 @@ class ValidateTest < BaseTest
       before { subject.validate({}).must_equal false }
 
       it { subject.errors.messages.must_equal(
-        :songs => ["is too short (minimum is 1 characters)"],
+        :songs => ["is too short (minimum is 1 character)"],
         :hit   => ["can't be blank"]) }
     end
 

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -261,6 +261,9 @@ class ValidateTest < BaseTest
       before { subject.validate({}).must_equal false }
 
       it do
+        # ensure that only hit and songs keys are present
+        subject.errors.messages.keys.sort.must_equal([:hit, :songs])
+        # validate content of hit and songs keys
         subject.errors.messages[:hit].must_equal(["can't be blank"])
         subject.errors.messages[:songs].first.must_match(/\Ais too short \(minimum is 1 characters?\)\z/)
       end

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -260,9 +260,10 @@ class ValidateTest < BaseTest
     describe "invalid" do
       before { subject.validate({}).must_equal false }
 
-      it { subject.errors.messages.must_equal(
-        :songs => ["is too short (minimum is 1 character)"],
-        :hit   => ["can't be blank"]) }
+      it do
+        subject.errors.messages[:hit].must_equal(["can't be blank"])
+        subject.errors.messages[:songs].first.must_match(/\Ais too short \(minimum is 1 characters?\)\z/)
+      end
     end
 
 


### PR DESCRIPTION
(1) First test had extra 's'.
(2) Second test incorrectly tested instance_of rather than kind_of when testing the reflection.  (See the [class hierarchy in active_record/reflection.rb](https://github.com/rails/docrails/blob/master/activerecord/lib/active_record/reflection.rb#L165-L174).)