### PR TITLE
Make namespaced forms return model for #to_model.

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -54,8 +54,11 @@ module Reform::Form::ActiveModel
 
       delegates :model, *[:persisted?, :to_key, :to_param, :id] # Uber::Delegates
 
-      def to_model # this is called somewhere in FormBuilder and ActionController.
-        self
+      unless method_defined?(:to_model)
+        def to_model # this is called somewhere in FormBuilder and ActionController.
+          # For namespaced forms (PersonForm::Special), we need to return the model name.
+          model
+        end
       end
     end
   end

--- a/lib/reform/form/composition.rb
+++ b/lib/reform/form/composition.rb
@@ -50,6 +50,10 @@ module Reform::Form::Composition
     mapper.new(fields).to_hash(*args) # do not map names, yet. this happens in #to_nested_hash
   end
 
+  def to_model
+    self
+  end
+
 private
   def aliased_model # we don't need an Expose as we save the Composition instance in the constructor.
     model

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -13,7 +13,7 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
   it { form.persisted?.must_equal true }
   it { form.to_key.must_equal [artist.id] }
   it { form.to_param.must_equal "#{artist.id}" }
-  it { form.to_model.must_equal form }
+  it { form.to_model.must_equal artist }
   it { form.id.must_equal artist.id }
 
   describe "::model_name" do
@@ -160,4 +160,17 @@ class ActiveModelWithCompositionTest < MiniTest::Spec
 
     AnotherForm.new(:song => rio).model[:song].must_equal rio
   end
+end
+
+class NamespacedFormTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    include Reform::Form::ActiveModel
+
+    class Sub < SongForm; end
+  end
+
+  let (:artist) { Artist.create(:name => "Frank Zappa") }
+  let (:form) { SongForm::Sub.new(artist) }
+
+  it { form.to_model.must_equal artist }
 end


### PR DESCRIPTION
While working with this basic setup today

```ruby
class PostForm < Reform::Form

  class Admin < PostForm; end

  class Normal < PostForm; end

  # def to_model
  #   model
  # end
end
```

I discovered that when sending my view a PostForm::Normal instance, the path generated for the form action (`= form_for @form do |post_form|`) was defaulting to `post_form_normals_path`.  After some digging, I found that this was due to `#to_model` and that uncommenting the above-defined `#to_model` method gave the expected behavior.

This change implements the expected behavior for non-composed forms and preserves the existing behavior for composed forms.