### PR TITLE
Fix using first error in uniqueness validator.

### DIFF
--- a/lib/reform/form/active_record.rb
+++ b/lib/reform/form/active_record.rb
@@ -30,7 +30,7 @@ module Reform::Form::ActiveRecord
 
       @klass = record.class # this is usually done in the super-sucky #setup method.
       super(record).tap do |res|
-        form.errors.add(property, record.errors.first.last) if record.errors.present?
+        form.errors.add(property, record.errors[property].first) if record.errors[property].present?
       end
     end
   end


### PR DESCRIPTION
Atm uniqueness validator is broken if we have more than one unique field.

Let we have model `Printer` with `name` and `serial_number` that are must be unique and the following form (I'm using Trb's syntax):

```ruby
  contract do
    property :name
    property :serial_number

    validates_uniqueness_of :name
    validates_uniqueness_of :serial_number
  end
```

Then if we already have `{ name: 'Printer 1', serial_number: '111' }` in database and try to submit a form with `{ name: 'Printer 1', serial_number: '222' }` it will mark both fields as non-unique. It's because we always copy _first error_ (which is related to `name` in our case).

To fix it we need to copy an error that is related to current property only.