### PR TITLE
We haven't had 2.0 virtual attributes by default yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,13 @@ end
 As with the built-in coercion, this setter is only called in `#validate`.
 
 
-## Virtual Attributes
+## Virtual Attributes (Reform 2.0)
+
+**Warning:** to enable this feature you should tell reform to use 2.0 semantics:
+```ruby
+# config/initializers/reform.rb
+Reform::Form.reform_2_0!
+```
 
 Virtual fields come in handy when there's no direct mapping to a model attribute or when you plan on displaying but not processing a value.
 

--- a/lib/reform/contract.rb
+++ b/lib/reform/contract.rb
@@ -152,13 +152,13 @@ module Reform
 
     def self.deprecate_virtual_and_empty!(options) # TODO: remove me in 2.0.
       if options.delete(:virtual)
-        warn "[Reform] The :virtual option has changed! Check https://github.com/apotonick/reform/wiki/Migration-Guide and have a good day."
+        warn "[Reform] The :virtual option will be changed! Check https://github.com/apotonick/reform/wiki/Migration-Guide and have a good day."
         options[:_readable] = true
         options[:_writeable] = false
       end
 
       if options[:empty]
-        warn "[Reform] The :empty option has changed! Check https://github.com/apotonick/reform/wiki/Migration-Guide and have a good day."
+        warn "[Reform] The :empty option will be changed! Check https://github.com/apotonick/reform/wiki/Migration-Guide and have a good day."
         options[:_readable]  = false
         options[:_writeable] = false
       end


### PR DESCRIPTION
When I tried to use virtual attributes as mentioned in original readme I was confused because it didn't work.  

This is a fix for readme and deprecation warning message to avoid confusion.
Also, I updated wiki page https://github.com/apotonick/reform/wiki/Migration-Guide