### PR TITLE
Run tests against new ruby versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.4
+  - ruby-head
+  - 2.2.0
+  - 2.1.5
   - 2.0.0
   - 1.9.3
 gemfile:
@@ -8,3 +10,7 @@ gemfile:
   - gemfiles/Gemfile.rails-3.2
   - gemfiles/Gemfile.rails-3.1
   - gemfiles/Gemfile.rails-3.0
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
I believe `2.1.5` and `2.2.0` is more up to date at the moment. Also, it's always better to know sooner if something is failing on ruby master.