### PR TITLE
Expose contract fields

### DIFF
--- a/lib/reform/contract.rb
+++ b/lib/reform/contract.rb
@@ -26,6 +26,10 @@ module Reform
 
     RESERVED_METHODS = [:model, :aliased_model, :fields, :mapper] # TODO: refactor that so we don't need that.
 
+    # This method is used so a form builder (specifically Formtastic) can infer the input fields
+    def form_object_fields
+      fields.to_h.keys
+    end
 
     module PropertyMethods
       def property(name, options={}, &block)


### PR DESCRIPTION
WIP: Need to check the [Formtastic PR](https://github.com/justinfrench/formtastic/pull/1142), then I add tests and doc before merge, just opened this PR so we can discuss seeing some code.

This PR is related to https://github.com/justinfrench/formtastic/issues/1141

My proposal to solve the problem on the issue above, without affecting the current Formtastic behavior with AR models.

When a Reform object is passed to Formtastic builder, its InputsHelper tries to discover the object field, if the object respond to `form_object_fields` (as suggested in this PR), Formtastic knows how to build the form for the object based on the specified fields.

//cc @justinfrench