### PR TITLE
Virtual: true doesn't prevent from writing to object

### DIFF
--- a/test/save_test.rb
+++ b/test/save_test.rb
@@ -103,6 +103,28 @@ class SaveTest < BaseTest
     it { label.saved?.must_equal nil }
   end
 
+  describe "virtual: true" do
+    Reform::Form.reform_2_0!
+
+    let(:form) do
+      Class.new(Reform::Form) do
+        property :some_unexisted_attribute, virtual: true
+
+        # Unexpectedly adding "writealbe: false" helps (despite the reform_2_0!)
+        # property :some_unexisted_attribute, virtual: true, writeable: false
+      end
+    end
+    let(:params) { { some_unexisted_attribute: 42} }
+
+    subject { form.new(hit) }
+
+    it "does not assign virtual attributes" do
+      subject.validate(params)
+      subject.save do |attributes|
+        assert_equal(attributes, {})
+      end
+    end
+  end
 
   # #save returns result (this goes into disposable soon).
   it { subject.save.must_equal true }


### PR DESCRIPTION
Virtual attributes don't really virtual. Reform returns them in `save` block. 
Adding `writeable: false` helps. That's weird because `virtual: true` [sets both `writeable` and `readable` to false][1].
Here is a test to reproduce.



[1]: https://github.com/apotonick/reform/blob/master/lib/reform/contract.rb#L43-L44