### PR TITLE
Include rails 4.2 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.0.0
   - 1.9.3
 gemfile:
+  - gemfiles/Gemfile.rails-4.2
   - gemfiles/Gemfile.rails-4.0
   - gemfiles/Gemfile.rails-3.2
   - gemfiles/Gemfile.rails-3.1


### PR DESCRIPTION
You mentioned in #198 that you'd like `.travis.yml` upgraded.  I saw that #209 had already upgraded the Ruby versions, but here it is with Rails 4.2 added.