### PR TITLE
Improve unique validator on model update

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -1,14 +1,13 @@
 class Reform::Form::UniqueValidator < ActiveModel::EachValidator
   def validate_each(form, attribute, value)
-    if form.model.persisted?
-      if form.model.class.where("#{attribute} = ? AND id <> ?", value, form.model.id).size > 0
-        form.errors.add attribute, "#{attribute} must be unique."
-      end
-    else
-      if form.model.class.where("#{attribute} = ?", value).size > 0
-        form.errors.add attribute, "#{attribute} must be unique."
-      end
-    end
+    # search for models with attribute equals to form field value
+    query = form.model.class.where(attribute => value)
+
+    # if model persisted, excluded own model from query
+    query = query.merge(form.model.class.where("id <> ?", form.model.id)) if form.model.persisted?
+
+    # if any models found, add error on attribute
+    form.errors.add(attribute, "#{attribute} must be unique.") if query.any?
   end
 end
 

--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -1,7 +1,14 @@
 class Reform::Form::UniqueValidator < ActiveModel::EachValidator
   def validate_each(form, attribute, value)
-    if form.model.class.where("#{attribute} = ?", value).size > 0
-      form.errors.add attribute, "#{attribute} must be unique."
+    if form.model.persisted?
+      if form.model.class.where("#{attribute} = ? AND id <> ?", value, form.model.id).size > 0
+        form.errors.add attribute, "#{attribute} must be unique."
+      end
+    else
+      if form.model.class.where("#{attribute} = ?", value).size > 0
+        form.errors.add attribute, "#{attribute} must be unique."
+      end
     end
   end
 end
+

--- a/test/uniqueness_test.rb
+++ b/test/uniqueness_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 require "reform/form/validation/unique_validator.rb"
 
-class UniquenessValidatorTest < MiniTest::Spec
+class UniquenessValidatorOnCreateTest < MiniTest::Spec
   class SongForm < Reform::Form
     property :title
     validates :title, unique: true
@@ -18,5 +18,24 @@ class UniquenessValidatorTest < MiniTest::Spec
     form = SongForm.new(Song.new)
     form.validate("title" => "How Many Tears").must_equal false
     form.errors.to_s.must_equal "{:title=>[\"title must be unique.\"]}"
+  end
+end
+
+class UniquenessValidatorOnUpdateTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    property :title
+    validates :title, unique: true
+  end
+
+  it do
+    Song.delete_all
+    @song = Song.create(title: "How Many Tears")
+
+    form = SongForm.new(@song)
+    form.validate("title" => "How Many Tears").must_equal true
+    form.save
+
+    form = SongForm.new(@song)
+    form.validate("title" => "How Many Tears").must_equal true
   end
 end


### PR DESCRIPTION
Unique validator was searching if there was some model with value the same as the form, but when we are updating (and obviously the object is already persisted), the sql will find an object, the same as we are trying to update, so we need to consider two cases:

1. on create:

search for any object with field with same value (case works perfectly)

2. on update:

search for any object with field with same value AND id different the form's model id, so we will never find the same object (now this PR is considering this case!)

and now unique validation works perfectly