### PR TITLE
Acceptance validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unrelased
+
+* Added `validates accept: true` validation as a replacement for `validates acceptance: true`. This validation will not write anything to model. Validation implementation is courtesy of Rails team, thanks!
+
 ## 2.0.3
 
 * `Form#valid?` is private now. Sorry for the inconvenience, but this has never been documented as public. Reason is that the only entry point for validation is `#validate` to give the form as less public API as possible and minimize misunderstandings.

--- a/README.md
+++ b/README.md
@@ -797,6 +797,10 @@ Both ActiveRecord and Mongoid modules will support "native" uniqueness support f
 
 You're encouraged to use Reform's non-writing `unique: true` validation, though. [Learn more](http://trailblazerb.org/gems/reform/validation.html)
 
+## Acceptance Validation
+
+You're encouraged to use Reform's non-writing `accept: true` validation as a replacement for ActiveRecord's `acceptance: true`.
+
 ## ActiveModel Compliance
 
 Forms in Reform can easily be made ActiveModel-compliant.

--- a/README.md
+++ b/README.md
@@ -801,6 +801,13 @@ You're encouraged to use Reform's non-writing `unique: true` validation, though.
 
 You're encouraged to use Reform's non-writing `accept: true` validation as a replacement for ActiveRecord's `acceptance: true`.
 
+```ruby
+class SongForm < Reform::Form
+  property :terms, virtual: true
+  validates :terms, accept: true
+end
+```
+
 ## ActiveModel Compliance
 
 Forms in Reform can easily be made ActiveModel-compliant.

--- a/lib/reform/form/validation/accept_validator.rb
+++ b/lib/reform/form/validation/accept_validator.rb
@@ -1,0 +1,22 @@
+# Rails acceptance validation that does not write to model.
+class Reform::Form::AcceptValidator < ActiveModel::EachValidator
+  def initialize(options)
+    super({ accepted: ["1", true] }.merge!(options))
+  end
+
+  def validate_each(form, attribute, value)
+    unless accepted_option?(value)
+      form.errors.add(attribute, :accepted, options)
+    end
+  end
+
+  private
+
+  def accepted_option?(value)
+    Array(options[:accepted]).include?(value)
+  end
+end
+
+Reform::Form::ActiveModel::Validations::Validator.class_eval do
+  AcceptValidator = Reform::Form::AcceptValidator
+end

--- a/test/accept_test.rb
+++ b/test/accept_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require "reform/form/validation/accept_validator"
+
+class AcceptValidatorTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    property :terms, virtual: true
+    validates :terms, accept: true
+  end
+
+  it do
+    form = SongForm.new(Song.new)
+    form.validate("terms" => false).must_equal false
+    form.errors.to_s.must_equal "{:terms=>[\"must be accepted\"]}"
+  end
+end
+
+class AcceptValidatorWithCustomValueTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    property :terms, virtual: true
+    validates :terms, accept: { accepted: "moo" }
+  end
+
+  it do
+    form = SongForm.new(Song.new)
+    form.validate("terms" => "moo").must_equal true
+  end
+end
+
+class AcceptValidatorWithCustomValuesTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    property :terms, virtual: true
+    validates :terms, accept: { accepted: ["OK", 42] }
+  end
+
+  it do
+    form = SongForm.new(Song.new)
+    form.validate("terms" => "OK").must_equal true
+  end
+
+  it do
+    form = SongForm.new(Song.new)
+    form.validate("terms" => 42).must_equal true
+  end
+end


### PR DESCRIPTION
Reform 2.0.1, Rails 4.1.10

I was trying to upgrade Trailblazer and friends to latest version and run into a couple of issues, this is one of them - acceptance validation no longer works.