### PR TITLE
Failing test to show that `valid?` duplicates messages

### DIFF
--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -142,4 +142,12 @@ class ErrorsTest < MiniTest::Spec
     # to_s is aliased to messages
     it { form.errors.to_s.must_equal "{:\"songs.title\"=>[\"can't be blank\"], :\"band.label.name\"=>[\"can't be blank\"]}" }
   end
+
+  describe "repeated validations" do
+    it do
+      form.validate("title" => "")
+      form.valid?
+      form.errors.messages.must_equal({:title=>["can't be blank"], :"band.label.name"=>["can't be blank"]})
+    end
+  end
 end


### PR DESCRIPTION
Reform 2.0.1

I haven't run into this case with normal usage, but I thought it makes sense to report it anyway.

What happens is that calling `valid?` after `validate({})` will duplicate errors message. Given already validated form

```ruby
{:title=>["can't be blank"], :"band.label.name"=>["can't be blank"]}
```

calling `validate?` will do

```ruby
{:title=>["can't be blank", "can't be blank"], :"band.label.name"=>["can't be blank"]}
```

the more times you call `valid?`, the more duplicated messages you get.