### PR TITLE
Catch date parse exception

### DIFF
--- a/lib/reform/form/multi_parameter_attributes.rb
+++ b/lib/reform/form/multi_parameter_attributes.rb
@@ -26,12 +26,16 @@ module Reform::Form::MultiParameterAttributes
     def params_to_date(year, month, day, hour, minute)
       return nil if [year, month, day].any?(&:blank?)
 
-      if hour.blank? && minute.blank?
-        Date.new(year.to_i, month.to_i, day.to_i) # TODO: test fails.
-      else
-        args = [year, month, day, hour, minute].map(&:to_i)
-        Time.zone ? Time.zone.local(*args) :
-          Time.new(*args)
+      begin
+        if hour.blank? && minute.blank?
+          Date.new(year.to_i, month.to_i, day.to_i) # TODO: test fails.
+        else
+          args = [year, month, day, hour, minute].map(&:to_i)
+          Time.zone ? Time.zone.local(*args) :
+            Time.new(*args)
+        end
+      rescue ArgumentError
+        nil
       end
     end
   end

--- a/test/multi_parameter_attributes_test.rb
+++ b/test/multi_parameter_attributes_test.rb
@@ -20,11 +20,8 @@ class ReformTest < ReformSpec
 
     it "handles invalid Time input" do
       date_of_birth_params = { "date_of_birth(1i)"=>"1950", "date_of_birth(2i)"=>"99", "date_of_birth(3i)"=>"1" }
-      assert_raises ArgumentError do
-        form.validate(date_of_birth_params)
-      end
-      # form.validate(date_of_birth_params)
-      # form.date_of_birth.must_equal nil
+      form.validate(date_of_birth_params)
+      form.date_of_birth.must_equal nil
     end
   end
 
@@ -48,11 +45,8 @@ class ReformTest < ReformSpec
     it "handles invalid Time input" do
       start_time_params = { "start_time(1i)"=>"2000", "start_time(2i)"=>"99", "start_time(3i)"=>"1", "start_time(4i)"=>"12", "start_time(5i)"=>"00" }
       form.validate(start_time_params)
-      assert_raises ArgumentError do
-        form.validate(start_time_params)
-      end
-      # form.validate(start_time_params)
-      # form.start_time.must_equal nil
+      form.validate(start_time_params)
+      form.start_time.must_equal nil
     end
   end
 

--- a/test/multi_parameter_attributes_test.rb
+++ b/test/multi_parameter_attributes_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class ReformTest < ReformSpec
+
+  describe "Date" do
+    Person = Struct.new(:date_of_birth)
+    let (:form) { DateOfBirthForm.new(Person.new) }
+
+    class DateOfBirthForm < Reform::Form
+      feature Reform::Form::ActiveModel::FormBuilderMethods
+      feature Reform::Form::MultiParameterAttributes
+      property :date_of_birth, type: Date, :multi_params => true
+    end
+
+    it "munges multi-param date fields into a valid Date attribute" do
+      date_of_birth_params = { "date_of_birth(1i)"=>"1950", "date_of_birth(2i)"=>"1", "date_of_birth(3i)"=>"1" }
+      form.validate(date_of_birth_params)
+      form.date_of_birth.must_equal Date.civil(1950, 1, 1)
+    end
+
+    it "handles invalid Time input" do
+      date_of_birth_params = { "date_of_birth(1i)"=>"1950", "date_of_birth(2i)"=>"99", "date_of_birth(3i)"=>"1" }
+      assert_raises ArgumentError do
+        form.validate(date_of_birth_params)
+      end
+      # form.validate(date_of_birth_params)
+      # form.date_of_birth.must_equal nil
+    end
+  end
+
+  describe "DateTime" do
+    Party = Struct.new(:start_time)
+    let (:form) { PartyForm.new(Party.new) }
+
+    class PartyForm < Reform::Form
+      feature Reform::Form::ActiveModel::FormBuilderMethods
+      feature Reform::Form::MultiParameterAttributes
+      property :start_time, type: DateTime, :multi_params => true
+    end
+
+    it "munges multi-param date and time fields into a valid Time attribute" do
+      start_time_params = { "start_time(1i)"=>"2000", "start_time(2i)"=>"1", "start_time(3i)"=>"1", "start_time(4i)"=>"12", "start_time(5i)"=>"00" }
+      time_format = "%Y-%m-%d %H:%M"
+      form.validate(start_time_params)
+      form.start_time.strftime(time_format).must_equal DateTime.strptime("2000-01-01 12:00", time_format)
+    end
+
+    it "handles invalid Time input" do
+      start_time_params = { "start_time(1i)"=>"2000", "start_time(2i)"=>"99", "start_time(3i)"=>"1", "start_time(4i)"=>"12", "start_time(5i)"=>"00" }
+      form.validate(start_time_params)
+      assert_raises ArgumentError do
+        form.validate(start_time_params)
+      end
+      # form.validate(start_time_params)
+      # form.start_time.must_equal nil
+    end
+  end
+
+end


### PR DESCRIPTION
When using multi-parameter attributes for date fields, an invalid date would raise an ArgumentError.  

I added a test for that case.  Then I added a commit to catch that exception and return nil.

params_to_date already has a guard clause that returns nil if year, month or day are blank.  How do you feel about an invalid date behaving the same as that guard clause?

Ref #142
