### PR TITLE
Make `valid?` private

### DIFF
--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -66,6 +66,8 @@ module Reform::Form::ActiveModel
       end
     end
 
+    private
+
     # Needs to be implemented by every validation backend and implements the
     # actual validation. See Reform::Form::Lotus, too!
     def valid?

--- a/lib/reform/form/lotus.rb
+++ b/lib/reform/form/lotus.rb
@@ -42,14 +42,15 @@ module Reform::Form::Lotus
     end
   end
 
+  def build_errors
+    Errors.new
+  end
+
+  private
 
   def valid?
     # DISCUSS: by using @fields here, we avoid setters being called. win!
     validator = Lotus::Validations::Validator.new(self.class.validations, @fields, errors)
     validator.validate
-  end
-
-  def build_errors
-    Errors.new
   end
 end


### PR DESCRIPTION
Per conversion in #263 

`valid?` is widely used method in Rails and Lotus apps whereas in Reform
this method is undocumented, is not a part of public interface, and
should be used only in Reform internals.

Making `valid?` private should raise awareness to developers that they
might be calling something they shouldn't.