### PR TITLE
Use I18n for error message in uniqueness validator

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -10,7 +10,7 @@ class Reform::Form::UniqueValidator < ActiveModel::EachValidator
     query = query.merge(model.class.where("id <> ?", model.id)) if model.persisted?
 
     # if any models found, add error on attribute
-    form.errors.add(attribute, "#{attribute} must be unique.") if query.any?
+    form.errors.add(attribute, :taken) if query.any?
   end
 end
 

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -1,7 +1,9 @@
 ---
 en:
   # custom validation error messages
-
+  errors:
+    messages:
+      taken: has already been taken
   activemodel:
     errors:
       models:
@@ -9,3 +11,4 @@ en:
           attributes:
             title:
               custom_error_message: Custom Error Message
+              taken: has already been taken

--- a/test/unique_test.rb
+++ b/test/unique_test.rb
@@ -19,7 +19,7 @@ class UniquenessValidatorOnCreateTest < MiniTest::Spec
 
     form = SongForm.new(Song.new)
     form.validate("title" => "How Many Tears").must_equal false
-    form.errors.to_s.must_equal "{:title=>[\"title must be unique.\"]}"
+    form.errors.to_s.must_equal "{:title=>[\"has already been taken\"]}"
   end
 end
 


### PR DESCRIPTION
Add :taken symbol as error to form if uniqueness validation fails. This
mimics the uniqueness validation from active model, making translation
of the error message possible, inheriting the default translations from
active_model / rails.