### PR TITLE
cast block hash to HWIA for active_record form

### DIFF
--- a/lib/reform/form/active_record.rb
+++ b/lib/reform/form/active_record.rb
@@ -20,6 +20,10 @@ module Reform::Form::ActiveRecord
     end
   end
 
+  def to_nested_hash(*)
+    super.with_indifferent_access
+  end
+
   class UniquenessValidator < ::ActiveRecord::Validations::UniquenessValidator
     include Reform::Form::ORM::UniquenessValidator
   end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -96,6 +96,15 @@ class ActiveRecordTest < MiniTest::Spec
       form.save {}
       Artist.where(:name => "Bad Religion").size.must_equal 0
     end
+
+    it "can access block params using string or hash key" do
+      Artist.delete_all
+      form.validate("artist" => {"name" => "Paul Gilbert"}, "title" => "The Gargoyle", "created_at" => "November 6, 1966")
+      form.save do |params|
+        params[:title].must_equal 'The Gargoyle'
+        params['title'].must_equal 'The Gargoyle'
+      end
+    end
   end
 end
 


### PR DESCRIPTION
fix issue for #249
BTW,  currently(the master branch) the hash for block params is: 
1. symbol access key for model of  composition form
2. string access key for attribute
would you mind to change it all to string key or symbl key, when no acitve_record, no AS:HWIA