### PR TITLE
Add scope options to unique validation

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -6,6 +6,12 @@ class Reform::Form::UniqueValidator < ActiveModel::EachValidator
     # search for models with attribute equals to form field value
     query = model.class.where(attribute => value)
 
+    # apply scope if options has been declared
+    Array(options[:scope]).each do |field|
+      # add condition to only check unique value with the same scope
+      query = query.where(field => form.send(field))
+    end
+
     # if model persisted, excluded own model from query
     query = query.merge(model.class.where("id <> ?", model.id)) if model.persisted?
 

--- a/test/unique_test.rb
+++ b/test/unique_test.rb
@@ -62,3 +62,34 @@ class UniqueWithCompositionTest < MiniTest::Spec
     form.save
   end
 end
+
+
+class UniqueValidatorWithScopeTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    include ActiveRecord
+    property :album_id
+    property :title
+    validates :title, unique: { scope: :album_id }
+  end
+
+  it do
+    Song.delete_all
+
+    album = Album.new
+    album.save
+
+    form = SongForm.new(Song.new)
+    form.validate(album_id: album.id, title: 'How Many Tears').must_equal true
+    form.save
+
+    form = SongForm.new(Song.new)
+    form.validate(album_id: album.id, title: 'How Many Tears').must_equal false
+    form.errors.to_s.must_equal "{:title=>[\"has already been taken\"]}"
+
+    album = Album.new
+    album.save
+
+    form = SongForm.new(Song.new)
+    form.validate(album_id: album.id, title: 'How Many Tears').must_equal true
+  end
+end


### PR DESCRIPTION
Simple scope option! Yey!

To use it:
`validates :title, unique: { scope: :album_id }`

It checks only song with the same title by album instead of all the songs available.