### PR TITLE
Validate unique inside an association that is persisted or not

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -1,22 +1,45 @@
 # Reform's own implementation for uniqueness which does not write to model.
 class Reform::Form::UniqueValidator < ActiveModel::EachValidator
   def validate_each(form, attribute, value)
+    has_error = false
     model = form.model_for_property(attribute)
+    scope = Array(options[:scope])
 
-    # search for models with attribute equals to form field value
-    query = model.class.where(attribute => value)
+    if value.is_a?(Array)
+      # validate in memory collection
+      # thank you: http://stackoverflow.com/questions/2772236/validates-uniqueness-of-in-destroyed-nested-model-rails
+      hashes = value.inject({}) do |hash, record|
+        key = scope.map { |a| record.send(a).to_s }.join
 
-    # apply scope if options has been declared
-    Array(options[:scope]).each do |field|
-      # add condition to only check unique value with the same scope
-      query = query.where(field => form.send(field))
+        # TODO: add support for marked_as_destruction? when a solution for _destroy is found
+        if key.blank?
+          key = record.object_id
+        end
+
+        hash[key] = record unless hash.has_key?(key)
+
+        hash
+      end
+
+      has_error = (value.length > hashes.length)
+    else
+      # search for models with attribute equals to form field value
+      query = model.class.where(attribute => value)
+
+      # apply scope if options has been declared
+      scope.each do |field|
+        # add condition to only check unique value with the same scope
+        query = query.where(field => form.send(field))
+      end
+
+      # if model persisted, excluded own model from query
+      query = query.merge(model.class.where("id <> ?", model.id)) if model.persisted?
+
+      # if any models found, add error on attribute
+      has_error = query.any?
     end
 
-    # if model persisted, excluded own model from query
-    query = query.merge(model.class.where("id <> ?", model.id)) if model.persisted?
-
-    # if any models found, add error on attribute
-    form.errors.add(attribute, :taken) if query.any?
+    form.errors.add(attribute, :taken) if has_error
   end
 end
 


### PR DESCRIPTION
The unique validation must check if the property to validate is a collection or a field. If it is a collection, it use the scope to compare each fields. Very useful when you have nested fields inside the same form where the user can add has many nested items that he wants. The nested fields are not yet save in the database so it must be check in another way then a query.

Thank you to: http://stackoverflow.com/questions/2772236/validates-uniqueness-of-in-destroyed-nested-model-rails

```
class AlbumForm < Reform::Form
    property :title
    validates :songs, unique: { scope: :title }

    collection :songs, :populate_if_empty => Song do
      property :title
    end
    [...]
```

It doesn't check `marked_for_destruction?` since `_destroy` is not yet support in `Reform`. Do you think it must be add if someone manually decide to call: `marked_for_destruction`? (`if key.blank? || record.try(:marked_for_destruction?)` instead on line 15)