### PR TITLE
Prevent Rails from adding methods to validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* `ActiveModel::Validator` prevents Rails from adding methods to it. This makes `acceptance` and `confirmation` validations work properly.
+
 ## 2.1
 
 ### Awesomeness

--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -72,6 +72,13 @@ module Reform::Form::ActiveModel
         def clone
           Class.new(self)
         end
+
+        # Prevent AM:V from mutating the validator class
+        def attr_reader(*)
+        end
+
+        def attr_writer(*)
+        end
       end
 
       def initialize(form, name)


### PR DESCRIPTION
The  `ActiveModel::Validations::AcceptanceValidator` and `ActiveModel::Validations::ConfirmationValidator` attempt to define `attr_reader` and `attr_writer` methods on the model, which conflicts with the delegate approach for implementing `Validator`.

#262 suggests to use our own `AcceptValidator`

This is another solution to make acceptance and confirmation validations work by preventing Rails from adding methods to the `Validator`. The accessors will now properly delegate to the form object.

A common pattern I saw in the gitter chat is people taking the validations out of their AR models and moving them to a `Reform::Form` (either with Trailblazer or without), so making sure that the default Rails validations work will really smooth the transition to TRB/Reform.

@apotonick I know you are tired of fixing Rails' shit and dealing with their wild assumptions. I hope you'll appreciate not having to come up with this solution yourself.