### PR TITLE
[Do Not Merge] Reproduction that skip_if doesn't work if the first item is skipped

### DIFF
--- a/test/skip_if_test.rb
+++ b/test/skip_if_test.rb
@@ -62,4 +62,11 @@ class SkipIfAllBlankTest < BaseTest
     form.songs.size.must_equal 1
     form.songs[0].title.must_equal "Apathy"
   end
+
+  it do
+    form = AlbumForm.new(OpenStruct.new(songs: []))
+    form.validate("songs" => [{"title"=>"", "length" => ""}, {"title"=>"Apathy"}]).must_equal true
+    form.songs.size.must_equal 1
+    form.songs[0].title.must_equal "Apathy"
+  end
 end


### PR DESCRIPTION
Found this while doing other work. This fails with the message:

```
NoMethodError: undefined method `validate!' for nil:NilClass
    /Users/shep/Projects/reform/lib/reform/contract/validate.rb:28:in `block (2 levels) in validate_nested!'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/disposable-0.2.0.rc1/lib/disposable/twin/property_processor.rb:24:in `block in collection!'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/disposable-0.2.0.rc1/lib/disposable/twin/property_processor.rb:24:in `collect'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/disposable-0.2.0.rc1/lib/disposable/twin/property_processor.rb:24:in `collection!'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/disposable-0.2.0.rc1/lib/disposable/twin/property_processor.rb:15:in `call'
    /Users/shep/Projects/reform/lib/reform/contract/validate.rb:28:in `block in validate_nested!'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/disposable-0.2.0.rc1/lib/disposable/twin/definitions.rb:22:in `block in each'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/declarative-0.0.5/lib/declarative/definitions.rb:30:in `each'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/declarative-0.0.5/lib/declarative/definitions.rb:30:in `each'
    /Users/shep/.rvm/gems/ruby-2.2.1/gems/disposable-0.2.0.rc1/lib/disposable/twin/definitions.rb:16:in `each'
    /Users/shep/Projects/reform/lib/reform/contract/validate.rb:26:in `validate_nested!'
    /Users/shep/Projects/reform/lib/reform/contract/validate.rb:10:in `validate!'
    /Users/shep/Projects/reform/lib/reform/contract/validate.rb:3:in `validate'
    /Users/shep/Projects/reform/lib/reform/form/validate.rb:23:in `validate'
    /Users/shep/Projects/reform/test/skip_if_test.rb:68:in `block in <class:SkipIfAllBlankTest>'
```

I'm willing to help fix, but would love some guidance on direction.