### PR TITLE
Updated Readme for copy_validations_from

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ class SongForm < Reform::Form
 end
 ```
 
-Be warned that we _do not_ encourage copying validations. You should rather move validation code into forms and not work on your model directly anymore.
+Be warned that we _do not_ encourage copying validations. You should rather move validation code into forms and not work on your model directly anymore. Also, please note that the ```copy_validations_from``` line _must_ go below your property definitions for the validations to copy correctly.
 
 ## Agnosticism: Mapping Data
 


### PR DESCRIPTION
This Readme update is driven by the following issue: https://github.com/apotonick/reform/issues/230

It is unreasonable to expect people to keep the copy_validations_from line under the property definitions. We should explicitly let people know this structure is required.