### PR TITLE
Tries to [Fix] #313 on upstream branch

### DIFF
--- a/lib/reform/form/populator.rb
+++ b/lib/reform/form/populator.rb
@@ -50,7 +50,7 @@ private
         index = args.first
         item = twin.original[index] and return item
 
-        twin.insert(index, run!(form, fragment, options)) # form.songs.insert(Song.new)
+        twin.insert([index, twin.count].min, run!(form, fragment, options)) # form.songs.insert(Song.new)
       else
         return if twin
 


### PR DESCRIPTION
- Resolve issue with adding and removing items in a collection in a single action

The app I'm working on is still using version 2.0.5 of reform, so my fork is only up to date since [this commit](https://github.com/apotonick/reform/commit/16ab6083926488b65b6232262ae69e2d7945528b), hence the merge conflicts. 

It would be nice to get this change incorporated into version 2.1, when that gets released. The most up to date version of the reform branch (something like 2.1.pre1, I think) doesn't work properly with the app, and I don't have time right now to figure out how to make it compatible. 

There are two skipped tests, but other than that, they all pass based on version 2.0.5. 