### PR TITLE
Fix require statement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ end
 To use dry-validation (recommended).
 
 ```ruby
-require "reform/form/lotus"
+require "reform/form/dry"
 Reform::Form.class_eval do
   include Reform::Form::Dry
 end


### PR DESCRIPTION
The [official documentation](http://trailblazer.to/gems/reform/#installation) states that when installing, you should require `reform/form/dry` when setting up `dry-validation`, not `reform/form/lotus` (as in the readme).

In Rails 4.2 and by only installing the reform gem (latest version as of this time of writing), using the instructions in the readme will result in a `LoadError`.

This should make things less confusing for people using the repo's documentation.

Hope this helps!