### PR TITLE
Expand uniqueness handling.

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -41,8 +41,9 @@ class Reform::Form::UniqueValidator < ActiveModel::EachValidator
       query = query.where(field => form.send(field))
     end
 
-    # if model persisted, query may return 0 or 1 rows, else 0
-    allow_count = model.persisted? ? 1 : 0
+    # if model is persisted and has the same value then count of 1 is allowed, in
+    # all other other cases it is 0
+    allow_count = model.persisted? && model.public_send(attribute) == value ? 1 : 0
     form.errors.add(attribute, :taken) if query.count > allow_count
   end
 end

--- a/test/unique_test.rb
+++ b/test/unique_test.rb
@@ -42,8 +42,16 @@ class UniquenessValidatorOnUpdateTest < MiniTest::Spec
     form = SongForm.new(@song)
     form.validate("title" => "How Many Tears").must_equal true
   end
-end
 
+  it do
+    Song.delete_all
+    Song.create(title: "How Many Tears")
+
+    @song = Song.create(title: "Baby Face")
+    form = SongForm.new(@song)
+    form.validate("title" => "How Many Tears").must_equal false
+  end
+end
 
 class UniqueWithCompositionTest < MiniTest::Spec
   class SongForm < Reform::Form


### PR DESCRIPTION
Handle uniqueness case when updating existing record attribute to the
value of another existing record attribute.

---

I run into issue when updating an attribute of existing record to the value of another existing record doesn't trigger uniqueness validation error. I adjusted the condition based on what it is being decided is it is not unique so that it checks we are updating the same record and in that case we are OK that count will return 1. In all other cases count should return 0 to make sure value is unique.