### PR TITLE
Add :parse option for property

### DIFF
--- a/lib/reform/form.rb
+++ b/lib/reform/form.rb
@@ -16,6 +16,11 @@ module Reform
     module Property
       # Add macro logic, e.g. for :populator.
       def property(name, options={}, &block)
+        if options.key?(:parse)
+          options[:deserializer] ||= {}
+          options[:deserializer][:writeable] = options.delete(:parse)
+        end
+
         definition = super # let representable sort out inheriting of properties, and so on.
         definition.merge!(deserializer: {}) unless definition[:deserializer] # always keep :deserializer per property.
 

--- a/test/parse_option_test.rb
+++ b/test/parse_option_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class ParseOptionTest < MiniTest::Spec
+  Comment = Struct.new(:content, :user)
+  User    = Struct.new(:name)
+
+  class CommentForm < Reform::Form
+    property :content
+    property :user, parse: false
+  end
+
+  let (:current_user) { User.new("Peter") }
+  let (:form) { CommentForm.new(Comment.new, user: current_user) }
+
+  it do
+    form.user.must_equal current_user
+
+    lorem = "Lorem ipsum dolor sit amet..."
+    form.validate("content" => lorem, "user" => "not the current user")
+
+    form.content.must_equal lorem
+    form.user.must_equal current_user
+  end
+
+  describe "using ':parse' option doesn't override other ':deserialize' options" do
+    class ArticleCommentForm < Reform::Form
+      property :content
+      property :article, deserializer: { instance: "Instance" }
+      property :user, parse: false, deserializer: { instance: "Instance" }
+    end
+
+    it do
+      ArticleCommentForm.definitions.get(:user)[:deserializer][:writeable].must_equal false
+      ArticleCommentForm.definitions.get(:user)[:deserializer][:instance].must_equal "Instance"
+
+      ArticleCommentForm.definitions.get(:article)[:deserializer][:writeable].must_equal true
+      ArticleCommentForm.definitions.get(:article)[:deserializer][:instance].must_equal "Instance"
+    end
+  end
+end


### PR DESCRIPTION
Allow defining *parse* properties that cannot be updated at `Form#validate`:

```ruby
User = Struct.new(:name, :admin)

class UserForm < Reform::Form
  property :name
  property :admin, parse: false
end

user = User.new("Peter", false)
form = UserForm.new(user)

form.validate("name" => "Joseph", "admin" => true)

form.name # returns "Joseph"
form.admin # returns false
```