### PR TITLE
ADD case_sensitive: false to unique validation

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -20,6 +20,10 @@
 # property :album_id
 # validates :title, unique: { scope: :album_id }
 #
+# Case sensitivity is true by default, but can be set to false:
+#
+# validates :title, unique: { case_sensitive: false }
+#
 # Just remove write access to the property if the field must not be change:
 # property :album_id, writeable: false
 # validates :title, unique: { scope: :album_id }
@@ -33,7 +37,11 @@ class Reform::Form::UniqueValidator < ActiveModel::EachValidator
     model = form.model_for_property(attribute)
 
     # search for models with attribute equals to form field value
-    query = model.class.where(attribute => value)
+    if options[:case_sensitive] == false
+      query = model.class.where("lower(#{attribute}) = ?", value.downcase)
+    else
+      query = model.class.where(attribute => value)
+    end
 
     # apply scope if options has been declared
     Array(options[:scope]).each do |field|

--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -38,7 +38,8 @@ class Reform::Form::UniqueValidator < ActiveModel::EachValidator
 
     # search for models with attribute equals to form field value
     if options[:case_sensitive] == false
-      query = model.class.where("lower(#{attribute}) = ?", value.downcase)
+      downcased_value = value.nil? ? value : value.downcase
+      query = model.class.where("lower(#{attribute}) = ?", downcased_value)
     else
       query = model.class.where(attribute => value)
     end

--- a/test/unique_test.rb
+++ b/test/unique_test.rb
@@ -41,6 +41,13 @@ class UniquenessValidatorOnCreateCaseInsensitiveTest < MiniTest::Spec
     form.validate("title" => "how many tears").must_equal false
     form.errors.to_s.must_equal "{:title=>[\"has already been taken\"]}"
   end
+
+  it do
+    Song.delete_all
+
+    form = SongForm.new(Song.new)
+    form.validate({}).must_equal true
+  end
 end
 
 class UniquenessValidatorOnCreateCaseSensitiveTest < MiniTest::Spec

--- a/test/unique_test.rb
+++ b/test/unique_test.rb
@@ -43,6 +43,25 @@ class UniquenessValidatorOnCreateCaseInsensitiveTest < MiniTest::Spec
   end
 end
 
+class UniquenessValidatorOnCreateCaseSensitiveTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    include ActiveRecord
+    property :title
+    validates :title, unique: { case_sensitive: true }
+  end
+
+  it do
+    Song.delete_all
+
+    form = SongForm.new(Song.new)
+    form.validate("title" => "How Many Tears").must_equal true
+    form.save
+
+    form = SongForm.new(Song.new)
+    form.validate("title" => "how many tears").must_equal true
+  end
+end
+
 class UniquenessValidatorOnUpdateTest < MiniTest::Spec
   class SongForm < Reform::Form
     include ActiveRecord
@@ -60,26 +79,6 @@ class UniquenessValidatorOnUpdateTest < MiniTest::Spec
 
     form = SongForm.new(@song)
     form.validate("title" => "How Many Tears").must_equal true
-  end
-end
-
-class UniquenessValidatorOnUpdateCaseInsensitiveTest < MiniTest::Spec
-  class SongForm < Reform::Form
-    include ActiveRecord
-    property :title
-    validates :title, unique: { case_sensitive: false }
-  end
-
-  it do
-    Song.delete_all
-    @song = Song.create(title: "How Many Tears")
-
-    form = SongForm.new(@song)
-    form.validate("title" => "How Many Tears").must_equal true
-    form.save
-
-    form = SongForm.new(@song)
-    form.validate("title" => "how many tears").must_equal true
   end
 end
 

--- a/test/unique_test.rb
+++ b/test/unique_test.rb
@@ -23,6 +23,25 @@ class UniquenessValidatorOnCreateTest < MiniTest::Spec
   end
 end
 
+class UniquenessValidatorOnCreateCaseInsensitiveTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    include ActiveRecord
+    property :title
+    validates :title, unique: { case_sensitive: false }
+  end
+
+  it do
+    Song.delete_all
+
+    form = SongForm.new(Song.new)
+    form.validate("title" => "How Many Tears").must_equal true
+    form.save
+
+    form = SongForm.new(Song.new)
+    form.validate("title" => "how many tears").must_equal false
+    form.errors.to_s.must_equal "{:title=>[\"has already been taken\"]}"
+  end
+end
 
 class UniquenessValidatorOnUpdateTest < MiniTest::Spec
   class SongForm < Reform::Form
@@ -44,6 +63,25 @@ class UniquenessValidatorOnUpdateTest < MiniTest::Spec
   end
 end
 
+class UniquenessValidatorOnUpdateCaseInsensitiveTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    include ActiveRecord
+    property :title
+    validates :title, unique: { case_sensitive: false }
+  end
+
+  it do
+    Song.delete_all
+    @song = Song.create(title: "How Many Tears")
+
+    form = SongForm.new(@song)
+    form.validate("title" => "How Many Tears").must_equal true
+    form.save
+
+    form = SongForm.new(@song)
+    form.validate("title" => "how many tears").must_equal true
+  end
+end
 
 class UniqueWithCompositionTest < MiniTest::Spec
   class SongForm < Reform::Form
@@ -94,6 +132,35 @@ class UniqueValidatorWithScopeTest < MiniTest::Spec
   end
 end
 
+class UniqueValidatorWithScopeAndCaseInsensitiveTest < MiniTest::Spec
+  class SongForm < Reform::Form
+    include ActiveRecord
+    property :album_id
+    property :title
+    validates :title, unique: { scope: :album_id, case_sensitive: false }
+  end
+
+  it do
+    Song.delete_all
+
+    album = Album.new
+    album.save
+
+    form = SongForm.new(Song.new)
+    form.validate(album_id: album.id, title: 'How Many Tears').must_equal true
+    form.save
+
+    form = SongForm.new(Song.new)
+    form.validate(album_id: album.id, title: 'how many tears').must_equal false
+    form.errors.to_s.must_equal "{:title=>[\"has already been taken\"]}"
+
+    album = Album.new
+    album.save
+
+    form = SongForm.new(Song.new)
+    form.validate(album_id: album.id, title: 'how many tears').must_equal true
+  end
+end
 class UniqueValidatorWithScopeArrayTest < MiniTest::Spec
   class SongForm < Reform::Form
     include ActiveRecord


### PR DESCRIPTION
This adds the option `case_sensitive: false` to UniqueValidator.
    
Example Usage:
    
`validates :title, unique: { case_sensitive: false }`

Tests included.