### PR TITLE
Fixing Contract.properties to handle empty options

### DIFF
--- a/lib/reform/contract.rb
+++ b/lib/reform/contract.rb
@@ -29,7 +29,7 @@ module Reform
 
     # FIXME: test me.
     def self.properties(*args)
-      options = args.pop if args.last.is_a?(Hash)
+      options = args.last.is_a?(Hash) ? args.pop : {}
       args.each { |name| property(name, options.dup) }
     end
 

--- a/test/contract_test.rb
+++ b/test/contract_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ContractTest < MiniTest::Spec
   Song  = Struct.new(:title, :album, :composer)
-  Album = Struct.new(:name, :songs, :artist)
+  Album = Struct.new(:name, :duration, :songs, :artist)
   Artist = Struct.new(:name)
 
   class ArtistForm < Reform::Form
@@ -11,6 +11,10 @@ class ContractTest < MiniTest::Spec
 
   class AlbumForm < Reform::Contract
     property :name
+
+    properties :duration
+    properties :year, :style, readable: false
+
     validation do
       key(:name).required
     end
@@ -36,13 +40,34 @@ class ContractTest < MiniTest::Spec
   let (:song_with_composer) { Song.new("Resist Stance", nil, composer) }
   let (:composer)           { Artist.new("Greg Graffin") }
   let (:artist)             { Artist.new("Bad Religion") }
-  let (:album)              { Album.new("The Dissent Of Man", [song, song_with_composer], artist) }
+  let (:album)              { Album.new("The Dissent Of Man", 123, [song, song_with_composer], artist) }
 
   let (:form) { AlbumForm.new(album) }
 
   # accept `property form: SongForm`.
   it do
     form.artist.must_be_instance_of ArtistForm
+  end
+
+  describe ".properties" do
+    it "defines a property when called with one argument" do
+      form.must_respond_to :duration
+    end
+
+    it "defines several properties when called with multiple arguments" do
+      form.must_respond_to :year
+      form.must_respond_to :style
+    end
+
+    it "passes options to each property when options are provided" do
+      readable = AlbumForm.new(album).options_for(:style)[:readable]
+      readable.must_equal false
+    end
+
+    it "returns the list of defined properties" do
+      returned_value = AlbumForm.properties(:hello, :world, virtual: true)
+      returned_value.must_equal [:hello, :world]
+    end
   end
 
   describe "#options_for" do


### PR DESCRIPTION
Previous to this commit, calling `properties` without providing
an options Hash would result in an attempt to dup `nil`.

This fixes the issues and adds basic specs for `Contract.properties`.

Relates to #371.