### PR TITLE
ensure heritage uses the resolved name 

### DIFF
--- a/lib/reform/validation.rb
+++ b/lib/reform/validation.rb
@@ -8,11 +8,10 @@ module Reform::Validation
 
     # DSL.
     def validation(name=:default, options={}, &block)
-      heritage.record(:validation, name, options, &block)
-
       options = deprecate_validation_positional_args(name, options)
       name    = options[:name] # TODO: remove in favor of kw args in 3.0.
 
+      heritage.record(:validation, name, options, &block)
       group = validation_groups.add(name, options)
 
       group.instance_exec(&block)


### PR DESCRIPTION
(same as validation group) from hash or positional args.  This is needed to be compatible with @fran-worley's #385, but with the deprecation change from @apotonick's 04c4063a0a87073811ca2170147540570b31dfcf.  The latest commit after fran's merge allowed a hash to be passed as a name to heritage. 