### PR TITLE
Raise custom error when no validation backend is loaded

### DIFF
--- a/lib/reform/validation.rb
+++ b/lib/reform/validation.rb
@@ -29,6 +29,11 @@ module Reform::Validation
 
       { name: :default }.merge(name)
     end
+
+    def validation_group_class
+      raise NoBackendError, 'no validation backend loaded. Please include a ' +
+                            'validation backend such as Reform::Form::Dry'
+    end
   end
 
   def self.included(includer)
@@ -37,6 +42,9 @@ module Reform::Validation
 
   def valid?
     Groups::Result.new(self.class.validation_groups).(self, errors)
+  end
+
+  class NoBackendError < RuntimeError
   end
 end
 


### PR DESCRIPTION
I was trying to create a simple subclass of Reform::Form and I kept getting hit with the cryptic error ``undefined local variable or method `validation_group_class'``. After digging around in the reform source code, I realised that the problem was that I hadn't loaded a validation backend such as `Reform::Form::Dry`, so my call to `validation` was making things explode.

A simple error, but easily made, especially if you're new to the gem. This PR adds a custom error object that makes it clearer what the problem is and will hopefully prevent the next person from having to go digging in the gem source.

The below test works for this, but I didn't commit it because it doesn't work (gives false positives) if `test_helper` is loaded, because test_helper loads Reform::Form::Dry. Not sure of a solution that wouldn't be more effort than it's worth.

```
require 'reform'
require 'minitest/autorun'

class ValidationBackendTest < MiniTest::Spec
  it 'no backend loaded' do
    assert_raises Reform::Validation::NoBackendError do
      class PersonForm < Reform::Form
        property :name

        validation do
          required(:name).maybe(:str?)
        end
      end
    end
  end
end
```