### PR TITLE
Clean up and restore some inherit_test code.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'minitest/autorun'
 require "representable/debug"
 require "declarative/testing"
 require "pp"
+require 'byebug'
 
 require "reform/form/dry"
 # setup test classes so we can test without dry being included
@@ -27,7 +28,7 @@ class BaseTest < MiniTest::Spec
     end
   end
 
-  Song   = Struct.new(:title, :length)
+  Song   = Struct.new(:title, :length, :rating)
   Album  = Struct.new(:title, :hit, :songs, :band)
   Band   = Struct.new(:label)
   Label  = Struct.new(:name)


### PR DESCRIPTION
The `subject.validate` tests can be restored with some fairly minor syntax changes to be compatible with dry-validation.

There may be reasons to keep some of these tests commented-out that I'm not aware of.

The motivation for this clean-up is that I'm encountering some odd behaviour (possibly a bug, possibly a misunderstanding on my part) around inherited populators, and having a more thorough set of tests here is a prerequisite for me writing some tests to verify whether my issue is a bug or not.

cheers