### PR TITLE
Draft of indexed errors implementation

### DIFF
--- a/lib/reform/errors.rb
+++ b/lib/reform/errors.rb
@@ -45,12 +45,10 @@ class Reform::Contract::Result::Errors
       hash[ [*prefix, k].join(".").to_sym] = v
     # if it's a collection, index the errors
     else
-      # create an array for collection key
-      hash[ [*prefix].join(".").to_sym] ||= Array.new
-      # create hash for index position
-      hash[ [*prefix].join(".").to_sym][i] ||= Hash.new
-      # add error for attribute key
-      hash[ [*prefix].join(".").to_sym][i][k] = v
+      # create attribute prefix with all attributes joined
+      attribute_prefix = [ *prefix ].join(".")
+      # then join with index and it's attribute name
+      hash[ ["#{attribute_prefix}[#{i}]", k].join(".").to_sym] = v
     end
   end
 

--- a/lib/reform/errors.rb
+++ b/lib/reform/errors.rb
@@ -1,6 +1,8 @@
 # Provides the old API for Rails and friends.
 # Note that this might become an optional "deprecation" gem in Reform 3.
 class Reform::Contract::Result::Errors
+  @@index_errors = false
+
   def initialize(result, form)
     @result        = result # DISCUSS: we don't use this ATM?
     @form          = form
@@ -10,17 +12,46 @@ class Reform::Contract::Result::Errors
   end
 
   # PROTOTYPING. THIS WILL GO TO A SEPARATE GEM IN REFORM 2.4/3.0.
-  DottedErrors = ->(form, prefix, hash) do
+  DottedErrors = ->(form, prefix, hash, i = nil) do
     result = form.to_result
-    result.messages.collect { |k,v| hash[ [*prefix, k].join(".").to_sym] = v }
+    if indexed_errors?
+      result.messages.collect do |k,v|
+        indexed_errors(prefix, hash, k, v, i)
+      end
+    else
+      result.messages.collect { |k,v| hash[ [*prefix, k].join(".").to_sym] = v }
+    end
 
     form.schema.each(twin: true) { |dfn|
       Disposable::Twin::PropertyProcessor.new(dfn, form).() do |frm, i|
         # DottedErrors.(form.send(dfn[:name])[i], [*prefix, dfn[:name], i], hash) and next if i
-        DottedErrors.(form.send(dfn[:name])[i], [*prefix, dfn[:name]], hash) and next if i
+        DottedErrors.(form.send(dfn[:name])[i], [*prefix, dfn[:name]], hash, i) and next if i
         DottedErrors.(form.send(dfn[:name]), [*prefix, dfn[:name]], hash)
       end
     }
+  end
+
+  def self.indexed_errors?
+    @@index_errors
+  end
+
+  def self.index_errors=(value)
+    @@index_errors = value
+  end
+
+  def self.indexed_errors(prefix, hash, k, v, i = nil)
+    # if no index, means not collection, show the error
+    if i.nil?
+      hash[ [*prefix, k].join(".").to_sym] = v
+    # if it's a collection, index the errors
+    else
+      # create an array for collection key
+      hash[ [*prefix].join(".").to_sym] ||= Array.new
+      # create hash for index position
+      hash[ [*prefix].join(".").to_sym][i] ||= Hash.new
+      # add error for attribute key
+      hash[ [*prefix].join(".").to_sym][i][k] = v
+    end
   end
 
   def messages(*args)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -104,6 +104,29 @@ class ErrorsTest < MiniTest::Spec
     end
   end
 
+  describe "indexed errors" do
+    before { form.validate(
+      "hit"   =>{"title" => ""},
+      "title" => "",
+      "songs" => [{"title" => ""}, {"title" => ""}]) } # FIXME: what happens if item must be filled?
+    
+    after { Reform::Contract::Result::Errors.index_errors = false }
+
+    it do
+      Reform::Contract::Result::Errors.index_errors = true
+      form.errors.messages.must_equal({
+        :title        => ["must be filled"],
+        :"hit.title"  => ["must be filled"],
+        :"songs"=> [
+          { title: ["must be filled"] },
+          { title: ["must be filled"] }
+        ],
+        :"band.label.name"=>["must be filled"]
+      })
+      form.errors.size.must_equal(4)
+    end
+  end
+
 
   describe "#validate with main form invalid" do
     it do

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -117,13 +117,11 @@ class ErrorsTest < MiniTest::Spec
       form.errors.messages.must_equal({
         :title        => ["must be filled"],
         :"hit.title"  => ["must be filled"],
-        :"songs"=> [
-          { title: ["must be filled"] },
-          { title: ["must be filled"] }
-        ],
+        :"songs[0].title"=> ["must be filled"],
+        :"songs[1].title"=> ["must be filled"],
         :"band.label.name"=>["must be filled"]
       })
-      form.errors.size.must_equal(4)
+      form.errors.size.must_equal(5)
     end
   end
 


### PR DESCRIPTION
Hello,

Sorry if it's implemented elsewhere, I tried to find but didn't find, that's why I wrote a test case / drafted implementation so we can discuss.

**Problem:**
When have an API, errors for collections are not indexed, so not sure about what element caused the error. Rails has implemented this behavior on https://github.com/rails/rails/pull/19686

Trying to set this configuration on my app, I wasn't successful, so implemented on Reform

**Solution:**
1. Add one test for exactly the indexed errors, making the default, the non indexed behavior
2. On `Reform::Contract::Result::Errors` if not using indexed errors, keep the usual behavior, else collect all the messages, but organized indexing for collections on the errors hash

TODO: @apotonick I know this class variable for configuration is stupid hahaha just wanted a _fast 
 switch_  for the test case, would it good how? as a feature?