### PR TITLE
Add full_messages_for support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'dry-validation', '~> 1.5.0'
+gem 'dry-validation'

--- a/lib/reform/errors.rb
+++ b/lib/reform/errors.rb
@@ -26,11 +26,15 @@ class Reform::Contract::Result::Errors
     @dotted_errors
   end
 
-  def full_messages
-	  @dotted_errors.collect { |path, errors|
-		  human_field = path.to_s.gsub(/([\.\_])+/, " ").gsub(/(\b\w)+/) { |s| s.capitalize }
-			 errors.collect { |message| "#{human_field} #{message}" }
-		}.flatten
+  def full_messages(errors = @dotted_errors)
+    errors.collect { |path, errors|
+      human_field = path.to_s.gsub(/([\.\_])+/, " ").gsub(/(\b\w)+/) { |s| s.capitalize }
+      errors.collect { |message| "#{human_field} #{message}" }
+    }.flatten
+  end
+
+  def full_messages_for(field)
+    full_messages(@dotted_errors.select{ |path| path.to_s == field.to_s })
   end
 
   def [](name)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -174,6 +174,21 @@ class ErrorsTest < MiniTest::Spec
     end
   end
 
+  describe "#full_messages_for" do
+    it "renders full messages for given field correctly" do
+      result = form.validate(
+        "title"   => "",
+        "artists" => [],
+        "band"    => {"name" => "", "label" => {"name" => ""}}
+      )
+
+      assert_equal result, false
+      assert_equal form.errors.full_messages_for(:title), ["Title must be filled"]
+      assert_equal form.errors.full_messages_for('band.name'), ["Band Name must be filled"]
+      assert_equal form.band.errors.full_messages_for(:name), ["Name must be filled"]
+    end
+  end
+
   describe "#add" do
     let(:album_title) { nil }
     it do


### PR DESCRIPTION
ActiveModel has added support to pick errors for specific field using `full_messages_for` method.

https://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-full_messages_for

SimpleForm seems to be using it to generate errors, but gives exception for reform's `errors` object.

```
undefined method `full_messages_for' for Reform::Contract::Result::Errors
```

This PR adds support to mimic the behaviour.